### PR TITLE
Fix bad markdown parse

### DIFF
--- a/src/board.jl
+++ b/src/board.jl
@@ -706,7 +706,7 @@ SquareSet:
  #  #  #  #  #  #  #  #
  -  -  -  -  -  -  -  -
  -  -  -  -  -  -  -  -
- ```
+```
 """
 function emptysquares(b::Board)::SquareSet
     -occupiedsquares(b)


### PR DESCRIPTION
An erroneous space in the docstrings for `emptysquares` caused the markdown to render poorly. See https://romstad.github.io/Chess.jl/dev/api/#Chess.emptysquares