### PR TITLE
Add option to pass pre-allocated `MoveList`s to `movefromsan`, `domoves`, etc.

### DIFF
--- a/src/pgn.jl
+++ b/src/pgn.jl
@@ -548,7 +548,7 @@ It is up to the caller to ensure that `movelist` has sufficient capacity.
 The optional parameter `skip` makes the function skip the first `skip` games of
 the file.
 """
-function gamesfromstream(stream::IO; annotations = false, skip = 0, movelist::Movelist = MoveList(200))
+function gamesfromstream(stream::IO; annotations = false, skip = 0, movelist::MoveList = MoveList(200))
     function createchannel(ch::Channel)
         pgnr = PGNReader(stream)
         

--- a/src/pgn.jl
+++ b/src/pgn.jl
@@ -415,13 +415,18 @@ end
 
 
 """
-    readgame(p::PGNReader; annotations=false)
+    readgame(p::PGNReader; annotations=false, movelist::MoveList=MoveList(200)))
 
 Attempts to parse a PGN game and use it to create a `Game` or a `SimpleGame`.
 
 If the optional parameter `annotations` is `true`, the return value will be a
 `Game` containing all comments, variations and numeric annotation glyphs in the
 PGN. Otherwise, it will be a `SimpleGame` with only the game moves.
+
+An optional, pre-allocated `MoveList` can be supplied, which will be passed to 
+all move generation functions (`movefromsan`, `moves`, etc.) in order to save
+space. For long games, this provides a large speed-up and space reduction. It 
+is up to the caller to ensure that `movelist` has sufficient capacity.
 
 This function assumes that the `PGNReader` is pointed at the beginning of a
 game. If you are not sure this is the case, call `gotonextgame!` on the
@@ -430,7 +435,7 @@ game. If you are not sure this is the case, call `gotonextgame!` on the
 If parsing fails or the notation contains illegal or ambiguous moves, the
 function raises a `PGNException`.
 """
-function readgame(p::PGNReader; annotations = false)
+function readgame(p::PGNReader; annotations = false, movelist::MoveList = MoveList(200))
     headers = readheaders(p)
     if isnothing(headers.fen)
         result = annotations ? Game() : SimpleGame()
@@ -471,7 +476,7 @@ function readgame(p::PGNReader; annotations = false)
         elseif t.ttype == symbol && !nullmoveseen
             # Try to parse the symbol as a move in short algebraic notation,
             # and add it to the game if successful
-            m = movefromsan(board(result), t.value)
+            m = movefromsan(board(result), t.value, movelist)
             if !isnothing(m)
                 if annotations
                     addmove!(result, m)
@@ -504,7 +509,7 @@ end
 
 
 """
-    gamesinfile(filename::String; annotations=false, skip=0)
+    gamesinfile(filename::String; annotations=false, skip=0, movelist::MoveList=MoveList(200))
 
 Creates a `Channel` of `Game`/`SimpleGame` objects read from the PGN file with
 the provided file name.
@@ -514,10 +519,15 @@ channel of `Game` objects containing all comments, variations and numeric
 annotation glyphs in the PGN. Otherwise, it will consist of `SimpleGame` objects
 with only the game moves.
 
+An optional, pre-allocated `MoveList` can be supplied, which will be passed to 
+all move generation functions (`movefromsan`, `moves`, etc.) in order to save
+space. For long games/files, this provides a large speed-up and space reduction. 
+It is up to the caller to ensure that `movelist` has sufficient capacity.
+
 The optional parameter `skip` makes the function skip the first `skip` games of
 the file.
 """
-function gamesinfile(filename::String; annotations = false, skip = 0)
+function gamesinfile(filename::String; annotations = false, skip = 0, movelist::MoveList = MoveList(200))
     function createchannel(ch::Channel)
         open(filename, "r") do io
             pgnr = PGNReader(io)
@@ -532,7 +542,7 @@ function gamesinfile(filename::String; annotations = false, skip = 0)
             end
 
             while !eof(pgnr.io)
-                put!(ch, readgame(pgnr, annotations = annotations))
+                put!(ch, readgame(pgnr, annotations = annotations, movelist))
                 gotonextgame!(pgnr)
             end
         end

--- a/src/san.jl
+++ b/src/san.jl
@@ -14,11 +14,17 @@ end
 
 
 """
-    movefromsan((b::Board, san::String))::Union{Move, Nothing}
+    movefromsan(b::Board, san::String, movelist::MoveList)::Union{Move,Nothing}
+    movefromsan(b::Board, san::String)::Union{Move,Nothing}
 
 Tries to read a move in Short Algebraic Notation.
 
 Returns `nothing` if the provided string is an impossible or ambiguous move.
+
+This internally calls `moves`, which can be supplied a pre-allocated `MoveList`
+in order to save time/space due to unnecessary allocations. If provided, the
+`movelist` parameter will be passed to `moves`. It is up to the caller to
+ensure that `movelist` has sufficient capacity.
 
 # Examples
 
@@ -26,12 +32,21 @@ Returns `nothing` if the provided string is an impossible or ambiguous move.
 julia> movefromsan(b, "Nf3")
 Move(g1f3)
 
+julia> movelist = MoveList(200)
+0-element MoveList
+
+julia> movefromsan(b, "Nf3", movelist)
+Move(g1f3)
+
 julia> movefromsan(b, "???") == nothing
 true
 ```
 """
-function movefromsan(b::Board, san::String)::Union{Move,Nothing}
-    ms = moves(b)
+movefromsan(b::Board, san::String)::Union{Move,Nothing} = movefromsan(b, san, MoveList(200))
+
+function movefromsan(b::Board, san::String, movelist::MoveList)::Union{Move,Nothing}
+    recycle!(movelist)
+    ms = moves(b, movelist)
 
     # Castling moves
     if islongcastle(san)

--- a/test/board.jl
+++ b/test/board.jl
@@ -349,3 +349,11 @@ begin
     b = fromfen("r3k2r/8/8/8/Pp6/8/8/4K3 b kq a3")
     @test fen(decompress(compress(b))) == fen(b)
 end
+
+begin
+    movelist = MoveList(200)
+    b = startboard()
+    new_board = domoves(b, "d4", "Nf6", "c4", "e6", "Nc3", "Bb4")
+    new_board_pre = domoves(b, "d4", "Nf6", "c4", "e6", "Nc3", "Bb4", movelist=movelist)
+    @test fen(new_board) == fen(new_board_pre)
+end

--- a/test/san.jl
+++ b/test/san.jl
@@ -1,43 +1,63 @@
 begin
+    local movelist = MoveList(200)
     local b = fromfen("2r2k2/1P6/8/8/p7/2N3N1/8/R3K2R w KQ -")
+    @test movefromsan(b, "b8=Q", movelist) == Move(SQ_B7, SQ_B8, QUEEN)
     @test movefromsan(b, "b8=Q") == Move(SQ_B7, SQ_B8, QUEEN)
     @test movetosan(b, Move(SQ_B7, SQ_B8, QUEEN)) == "b8=Q"
+    @test movefromsan(b, "bxc8=R+", movelist) == Move(SQ_B7, SQ_C8, ROOK)
     @test movefromsan(b, "bxc8=R+") == Move(SQ_B7, SQ_C8, ROOK)
     @test movetosan(b, Move(SQ_B7, SQ_C8, ROOK)) == "bxc8=R+"
+    @test movefromsan(b, "Nxa4", movelist) == Move(SQ_C3, SQ_A4)
     @test movefromsan(b, "Nxa4") == Move(SQ_C3, SQ_A4)
     @test movetosan(b, Move(SQ_C3, SQ_A4)) == "Nxa4"
+    @test movefromsan(b, "Nge4", movelist) == Move(SQ_G3, SQ_E4)
     @test movefromsan(b, "Nge4") == Move(SQ_G3, SQ_E4)
     @test movetosan(b, Move(SQ_G3, SQ_E4)) == "Nge4"
+    @test movefromsan(b, "Nce4", movelist) == Move(SQ_C3, SQ_E4)
     @test movefromsan(b, "Nce4") == Move(SQ_C3, SQ_E4)
     @test movetosan(b, Move(SQ_C3, SQ_E4)) == "Nce4"
     @test isnothing(movefromsan(b, "Ne4"))
+    @test movefromsan(b, "O-O-O", movelist) == Move(SQ_E1, SQ_C1)
     @test movefromsan(b, "O-O-O") == Move(SQ_E1, SQ_C1)
     @test movetosan(b, Move(SQ_E1, SQ_C1)) == "O-O-O"
+    @test movefromsan(b, "O-O+", movelist) == Move(SQ_E1, SQ_G1)
     @test movefromsan(b, "O-O+") == Move(SQ_E1, SQ_G1)
     @test movetosan(b, Move(SQ_E1, SQ_G1)) == "O-O+"
 
     b = fromfen("2r2k2/1P6/8/8/pb6/2N3N1/8/R3K2R w KQ -")
+    @test movefromsan(b, "Ne4", movelist) == Move(SQ_G3, SQ_E4)
     @test movefromsan(b, "Ne4") == Move(SQ_G3, SQ_E4)
     @test movetosan(b, Move(SQ_G3, SQ_E4)) == "Ne4"
 
     b = fromfen("4k3/R7/8/8/8/8/8/R3K3 w -")
+    @test isnothing(movefromsan(b, "Ra6", movelist))
     @test isnothing(movefromsan(b, "Ra6"))
+    @test movefromsan(b, "R1a6", movelist) == Move(SQ_A1, SQ_A6)
     @test movefromsan(b, "R1a6") == Move(SQ_A1, SQ_A6)
     @test movetosan(b, Move(SQ_A1, SQ_A6)) == "R1a6"
+    @test movefromsan(b, "R7a6", movelist) == Move(SQ_A7, SQ_A6)
     @test movefromsan(b, "R7a6") == Move(SQ_A7, SQ_A6)
     @test movetosan(b, Move(SQ_A7, SQ_A6)) == "R7a6"
 
     b = fromfen("4k3/8/8/3q1q2/3q1q2/8/8/4K3 b -")
+    @test isnothing(movefromsan(b, "Qde4#", movelist))
+    @test isnothing(movefromsan(b, "Qfe4#", movelist))
+    @test isnothing(movefromsan(b, "Q4e4#", movelist))
+    @test isnothing(movefromsan(b, "Q5e4#", movelist))
     @test isnothing(movefromsan(b, "Qde4#"))
     @test isnothing(movefromsan(b, "Qfe4#"))
     @test isnothing(movefromsan(b, "Q4e4#"))
     @test isnothing(movefromsan(b, "Q5e4#"))
+    @test movefromsan(b, "Qd4e4#", movelist) == Move(SQ_D4, SQ_E4)
     @test movefromsan(b, "Qd4e4#") == Move(SQ_D4, SQ_E4)
     @test movetosan(b, Move(SQ_D4, SQ_E4)) == "Qd4e4#"
+    @test movefromsan(b, "Qd5e4#", movelist) == Move(SQ_D5, SQ_E4)
     @test movefromsan(b, "Qd5e4#") == Move(SQ_D5, SQ_E4)
     @test movetosan(b, Move(SQ_D5, SQ_E4)) == "Qd5e4#"
+    @test movefromsan(b, "Qf4e4#", movelist) == Move(SQ_F4, SQ_E4)
     @test movefromsan(b, "Qf4e4#") == Move(SQ_F4, SQ_E4)
     @test movetosan(b, Move(SQ_F4, SQ_E4)) == "Qf4e4#"
+    @test movefromsan(b, "Qf5e4#", movelist) == Move(SQ_F5, SQ_E4)
     @test movefromsan(b, "Qf5e4#") == Move(SQ_F5, SQ_E4)
     @test movetosan(b, Move(SQ_F5, SQ_E4)) == "Qf5e4#"
 end


### PR DESCRIPTION
This exposes an optional parameter to pass a pre-allocated `MoveList` to several functions that can use it. In particular, it allows one to pass a pre-allocated `MoveList` to `movefromsan`, which is called internally in many places, and which in turn calls `moves`, which allocates a large `MoveList` unless otherwise supplied one.

One notable case where this causes a slowdown is in the `PGN` code, where `movetosan` is called frequently. This PR also changes `readgame` and `gamesfromfile` to pre-allocate a `MoveList` that is used throughout the game parsing via the newly exposed parameters.

Below is a benchmark on a reasonably long single game to demonstrate. Please note the allocation amount and number.

Before:

```julia
julia> pgn = "1. e4 c6 2. Nf3 d5 3. exd5 cxd5 4. d4 Nc6 5. Nc3 e6 6. Be2 Bd6 7. O-O Nf6 8. Bg5 O-O 9. Qd2 Be7 10. Rfe1 Qc7 11. Bf4 Qd7 12. Bb5 a6 13. Ba4 b5 14. Bb3 Qa7 15. Nh4 Qd7 16. Bh6 gxh6 17. Qxh6 Ne4 18. Nxe4 dxe4 19. Rxe4 f5 20. Rxe6 Kh8 21. Nxf5 Rxf5 22. Rae1 Bf8 23. Qh3 Rg5 24. Re1e4 Qg7 25. g3 Bxe6 26. Bxe6 Re8 27. d5 Ne5 28. f4 Nf3+ 29. Kh1 Rg6 30. f5 Rg5 31. Kg2 Nd4 32. c3 Nxe6 33. dxe6 Bd6 34. g4 Qf6 35. Qd3 Bb8 36. Qd7 Qh6 37. e7 Qxh2+ 38. Kf3 Qg3+ 39. Ke2 Qg2+ 40. Kd1 Qxe4 41. Qxe8+ Rg8 42. Qf7 Qxg4+ 43. Kc2 Qg2+ 44. Kb3 a5 45. e8=Q a4+ 46. Ka3 Bd6+ 47. b4 axb3+ 48. Kxb3 Rxe8 49. Qxe8+ Kg7 50. Qd7+ Kh6 51. Qxd6+ Kg5 52. f6 Qf3 53. Qe5+ Kg6 54. Qxb5 Qxf6 55. a4 Qe6+ 56. Ka3 Qd6+ 57. Qb4 Qd3 58. a5 h5 59. Qb6+ Kg5 60. Qc5+ Kg4 61. Kb4 Qb1+ 62. Kc4 Qa2+ 63. Kd3 Qb1+ 64. Kc4 Qa2+ 65. Kd4 Qd2+ 66. Kc4 Qa2+ 67. Kb5 Qb3+ 68. Qb4+ Qxb4+ 69. Kxb4 h4 70. a6 h3 71. a7 h2 72. a8=Q h1=B 73. Qxh1 Kf4 74. c4 Kg3 75. Qe1+ Kf3 76. Qd2 Ke4 77. Qc3 Kf4 78. Qd3 Ke5 79. c5 Ke6 80. c6 Ke5 81. c7 Ke6 82. Qd4 Ke7 83. c8=Q Kf7 84. Qd6 Kg7 85. Qcc7+ Kg8 86. Qdd8# 1-0";

julia> @benchmark Chess.PGN.gamefromstring(pgn)
BenchmarkTools.Trial: 8796 samples with 1 evaluation.
 Range (min … max):  516.862 μs …   3.413 ms  ┊ GC (min … max): 0.00% … 83.62%
 Time  (median):     538.861 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   564.681 μs ± 255.772 μs  ┊ GC (mean ± σ):  4.45% ±  8.08%

    ▁  █▅                                                         
  ▄█▄▃██▄▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▂▁▂▁▂▁▂▁▂▁▁▂▂▂▂▂▁▂▁▂ ▂
  517 μs           Histogram: frequency by time          793 μs <

 Memory estimate: 441.47 KiB, allocs estimate: 3036.
```

This PR:

```julia
julia> @benchmark Chess.PGN.gamefromstring(pgn)
BenchmarkTools.Trial: 9774 samples with 1 evaluation.
 Range (min … max):  487.603 μs …   4.636 ms  ┊ GC (min … max): 0.00% … 88.99%
 Time  (median):     493.645 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   508.066 μs ± 212.320 μs  ┊ GC (mean ± σ):  2.26% ±  4.79%

   ▁▄▆███▇▆▆▅▄▃▃▂▂▁    ▁                                        ▂
  ▆█████████████████▇█▇██████▇▇▆▆▆▆▆▅▂▆▇▇██▇▇▇▇▇▆▇▅▅▄▅▅▆▅▆▅▇▆▆▆ █
  488 μs        Histogram: log(frequency) by time        543 μs <

 Memory estimate: 136.00 KiB, allocs estimate: 2696.
```