### PR TITLE
Fix illegal move generation due to castle rights

### DIFF
--- a/src/board.jl
+++ b/src/board.jl
@@ -1377,25 +1377,25 @@ function updatecastlerights!(b::Board, f::Square, t::Square)
     crights = b.castlerights
     if t == kingsquare(b, WHITE)
         b.castlerights &= ~3
-    elseif t == kingsquare(b, BLACK)
+    end
+    if t == kingsquare(b, BLACK)
         b.castlerights &= ~12
-    else
-        if f == Square(kingsidecastlefile(b), RANK_1) ||
-           t == Square(kingsidecastlefile(b), RANK_1)
-            b.castlerights &= ~1
-        end
-        if f == Square(queensidecastlefile(b), RANK_1) ||
-           t == Square(queensidecastlefile(b), RANK_1)
-            b.castlerights &= ~2
-        end
-        if f == Square(kingsidecastlefile(b), RANK_8) ||
-           t == Square(kingsidecastlefile(b), RANK_8)
-            b.castlerights &= ~4
-        end
-        if f == Square(queensidecastlefile(b), RANK_8) ||
-           t == Square(queensidecastlefile(b), RANK_8)
-            b.castlerights &= ~8
-        end
+    end
+    if f == Square(kingsidecastlefile(b), RANK_1) ||
+        t == Square(kingsidecastlefile(b), RANK_1)
+        b.castlerights &= ~1
+    end
+    if f == Square(queensidecastlefile(b), RANK_1) ||
+        t == Square(queensidecastlefile(b), RANK_1)
+        b.castlerights &= ~2
+    end
+    if f == Square(kingsidecastlefile(b), RANK_8) ||
+        t == Square(kingsidecastlefile(b), RANK_8)
+        b.castlerights &= ~4
+    end
+    if f == Square(queensidecastlefile(b), RANK_8) ||
+        t == Square(queensidecastlefile(b), RANK_8)
+        b.castlerights &= ~8
     end
     b.key ⊻= zobcastle(crights)
     b.key ⊻= zobcastle(b.castlerights)

--- a/test/board.jl
+++ b/test/board.jl
@@ -349,3 +349,14 @@ begin
     b = fromfen("r3k2r/8/8/8/Pp6/8/8/4K3 b kq a3")
     @test fen(decompress(compress(b))) == fen(b)
 end
+
+# test for issue #26
+begin
+    b = fromfen("6Q1/8/5Q2/2p1B3/1bPpP3/1P3P2/PkPN2B1/R3K3 b Q - 0 48")
+    @test !cancastlekingside(b, WHITE)
+    @test cancastlequeenside(b, WHITE)
+
+    domove!(b, "Kxa1")
+    @test !cancastlekingside(b, WHITE)
+    @test !cancastlequeenside(b, WHITE)
+end


### PR DESCRIPTION
This resolves #26 by properly updating castle rights when the opposing king captures a rook on a side where castling was still available.
