### PR TITLE
Reduce allocations in `san.jl` by using `@views`

### DIFF
--- a/src/san.jl
+++ b/src/san.jl
@@ -2,13 +2,13 @@ export movefromsan, movetosan, variationtosan
 
 
 function islongcastle(san)
-    (length(san) ≥ 5 && (san[1:5] == "O-O-O" || san[1:5] == "0-0-0")) ||
+    @views (length(san) ≥ 5 && (san[1:5] == "O-O-O" || san[1:5] == "0-0-0")) ||
         (length(san) ≥ 3 && (san[1:3] == "OOO" || san[1:3] == "000"))
 end
 
 
 function isshortcastle(san)
-    (length(san) ≥ 3 && (san[1:3] == "O-O" || san[1:3] == "0-0")) ||
+    @views (length(san) ≥ 3 && (san[1:3] == "O-O" || san[1:3] == "0-0")) ||
         (length(san) ≥ 2 && (san[1:2] == "OO" || san[1:2] == "00"))
 end
 
@@ -81,8 +81,7 @@ function movefromsan(b::Board, san::String)::Union{Move,Nothing}
 
     # Destination square
     if left < right
-        #t = squarefromstring(s[end - 1:end])
-        t = squarefromstring(s[right-1:right])
+        @views t = squarefromstring(s[right-1:right])
         right -= 2
     else
         return nothing

--- a/src/square.jl
+++ b/src/square.jl
@@ -360,7 +360,7 @@ end
 
 
 """
-    squarefromstring(s::String)
+    squarefromstring(s::AbstractString)
 
 Tries to convert a string to a `Square`.
 
@@ -387,7 +387,7 @@ julia> squarefromstring("g1f3")
 SQ_G1
 ```
 """
-function squarefromstring(s::String)::Union{Square,Nothing}
+function squarefromstring(s::AbstractString)::Union{Square,Nothing}
     if length(s) < 2
         nothing
     else


### PR DESCRIPTION
This removes a few string allocations in `san.jl` by replacing string slicing with views.

For a quick malloc profile, I used:

```julia
julia> pgn = "1. e4 c6 2. Nf3 d5 3. exd5 cxd5 4. d4 Nc6 5. Nc3 e6 6. Be2 Bd6 7. O-O Nf6 8. Bg5 O-O 9. Qd2 Be7 10. Rfe1 Qc7 11. Bf4 Qd7 12. Bb5 a6 13. Ba4 b5 14. Bb3 Qa7 15. Nh4 Qd7 16. Bh6 gxh6 17. Qxh6 Ne4 18. Nxe4 dxe4 19. Rxe4 f5 20. Rxe6 Kh8 21. Nxf5 Rxf5 22. Rae1 Bf8 23. Qh3 Rg5 24. Re1e4 Qg7 25. g3 Bxe6 26. Bxe6 Re8 27. d5 Ne5 28. f4 Nf3+ 29. Kh1 Rg6 30. f5 Rg5 31. Kg2 Nd4 32. c3 Nxe6 33. dxe6 Bd6 34. g4 Qf6 35. Qd3 Bb8 36. Qd7 Qh6 37. e7 Qxh2+ 38. Kf3 Qg3+ 39. Ke2 Qg2+ 40. Kd1 Qxe4 41. Qxe8+ Rg8 42. Qf7 Qxg4+ 43. Kc2 Qg2+ 44. Kb3 a5 45. e8=Q a4+ 46. Ka3 Bd6+ 47. b4 axb3+ 48. Kxb3 Rxe8 49. Qxe8+ Kg7 50. Qd7+ Kh6 51. Qxd6+ Kg5 52. f6 Qf3 53. Qe5+ Kg6 54. Qxb5 Qxf6 55. a4 Qe6+ 56. Ka3 Qd6+ 57. Qb4 Qd3 58. a5 h5 59. Qb6+ Kg5 60. Qc5+ Kg4 61. Kb4 Qb1+ 62. Kc4 Qa2+ 63. Kd3 Qb1+ 64. Kc4 Qa2+ 65. Kd4 Qd2+ 66. Kc4 Qa2+ 67. Kb5 Qb3+ 68. Qb4+ Qxb4+ 69. Kxb4 h4 70. a6 h3 71. a7 h2 72. a8=Q h1=B 73. Qxh1 Kf4 74. c4 Kg3 75. Qe1+ Kf3 76. Qd2 Ke4 77. Qc3 Kf4 78. Qd3 Ke5 79. c5 Ke6 80. c6 Ke5 81. c7 Ke6 82. Qd4 Ke7 83. c8=Q Kf7 84. Qd6 Kg7 85. Qcc7+ Kg8 86. Qdd8# 1-0";

julia> s = Chess.PGN.gamefromstring(pgn);
```
The top allocations are as follows, with the items marked `>` being removed by this PR:

``` diff
 CoverageTools.MallocInfo(1280, "./board.jl.5394.mem", 1622)
 > CoverageTools.MallocInfo(5408, "./san.jl.5394.mem", 85)
 > CoverageTools.MallocInfo(9664, "./san.jl.5394.mem", 5)
 CoverageTools.MallocInfo(12320, "./san.jl.5394.mem", 54)
 CoverageTools.MallocInfo(16512, "./pgn.jl.5394.mem", 161)
 CoverageTools.MallocInfo(17968, "./game.jl.5394.mem", 792)
 > CoverageTools.MallocInfo(19776, "./san.jl.5394.mem", 11)
 CoverageTools.MallocInfo(49536, "./pgn.jl.5394.mem", 147)
 CoverageTools.MallocInfo(314640, "./san.jl.5394.mem", 34)
```

Note that the largest one, ` CoverageTools.MallocInfo(314640, "./san.jl.5394.mem", 34)`, is addressed by #27, but since this change does not depend on that PR, I didn't use it for the base.

--------------------------------------------------------------------

Benchmarking shows reduced allocations (`-7.7%` memory, `-35.9%` # allocations), but not much speedup (potentially due to #27 not being used).

Main:

```julia
 julia> @benchmark Chess.PGN.gamefromstring(pgn)
BenchmarkTools.Trial: 8911 samples with 1 evaluation.
 Range (min … max):  516.483 μs …   3.344 ms  ┊ GC (min … max): 0.00% … 82.79%
 Time  (median):     527.068 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   557.378 μs ± 253.854 μs  ┊ GC (mean ± σ):  4.47% ±  8.08%

   █▂                                                            
  ▃██▅▅▇▄▃▂▂▂▂▂▂▂▁▁▁▂▁▁▁▁▁▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▁▁▂▁▂▁▁▂▂▂▁▂▁▁▁▂▂▁▂ ▂
  516 μs           Histogram: frequency by time          794 μs <

 Memory estimate: 441.47 KiB, allocs estimate: 3036.
```

This PR:
```julia
 julia> @benchmark Chess.PGN.gamefromstring(pgn)
BenchmarkTools.Trial: 9061 samples with 1 evaluation.
 Range (min … max):  519.465 μs …   2.822 ms  ┊ GC (min … max): 0.00% … 75.97%
 Time  (median):     527.779 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   548.169 μs ± 181.330 μs  ┊ GC (mean ± σ):  3.10% ±  7.30%

  ▂██▆▄▂                                                        ▂
  ███████▇▆▇█▇▇▇▇▅▄▃▃▄▃▃▃▃▃▃▁▃▁▄▇▆▄▄▃▆█▇▅▄▄▃▃▃▃▁▄▁▁▄▃▃▁▃▃▁▁▁▁▁▄ █
  519 μs        Histogram: log(frequency) by time        745 μs <

 Memory estimate: 407.44 KiB, allocs estimate: 1947.
```