### PR TITLE
Optimize `issymbolstart` and `issymbolcontinuation`

### DIFF
--- a/src/pgn.jl
+++ b/src/pgn.jl
@@ -67,12 +67,14 @@ end
 
 
 function issymbolstart(c::Char)::Bool
-    occursin(c, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-")
+    ('a' <= c <= 'z') || ('A' <= c <= 'Z') || ('0' <= c <= '9') || (c == '-')
 end
 
 
 function issymbolcontinuation(c::Char)::Bool
-    occursin(c, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_+#=:-/")
+    (('a' <= c <= 'z') || ('A' <= c <= 'Z') || ('0' <= c <= '9') || (c == '-')
+    || (c == '_') || (c == '+') || (c == '#') || (c == '=') || (c == ':')
+    || (c == '/'))
 end
 
 


### PR DESCRIPTION
This PR optimizes `issymbolstart` and `issymbolcontinuation` by removing a linear `occursin` subroutine and replacing it with direct `Char` range comparisons.

A quick benchmark shows a `~5.8%` speedup when reading a game from a string. This is because `issymbolstart` and `issymbolcontinuation` are called on each token read (possibly twice, if asserts are turned on), so it is pretty hot in PGN reading code.

----------------------------------------------------------------------
Benchmarks (the routines, followed by a game parse):

The new implementation provides a `~92.3%` speedup.

```julia
julia> function f(c)
             occursin(c, "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-")
       end

julia> function g(c)
             ('a' <= c <= 'z') || ('A' <= c <= 'Z') || ('0' <= c <= '9') || (c == '-')
       end
g (generic function with 1 method)

julia> sum(f.(x)), sum(g.(x))
(2495, 2495)

julia> x = Char.(rand(UInt8, 10000));

julia> @benchmark sum(f.(x)) setup=shuffle!(x)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  226.780 μs …  2.945 ms  ┊ GC (min … max): 0.00% … 92.12%
 Time  (median):     230.353 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   231.065 μs ± 27.380 μs  ┊ GC (mean ± σ):  0.12% ±  0.92%

           ▂▅▇▇▇█▆▅▅▅▅▅▄▄▄▃▃▂▁▁                                 
  ▁▁▁▁▁▂▃▅▇█████████████████████▆▆▅▅▄▄▄▃▃▃▂▂▂▂▂▂▁▂▁▁▁▁▁▁▁▁▁▁▁▁ ▄
  227 μs          Histogram: frequency by time          238 μs <

 Memory estimate: 5.62 KiB, allocs estimate: 7.

julia> @benchmark sum(g.(x)) setup=shuffle!(x)
BenchmarkTools.Trial: 10000 samples with 1 evaluation.
 Range (min … max):  16.055 μs …  2.659 ms  ┊ GC (min … max): 0.00% … 99.27%
 Time  (median):     17.617 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   17.710 μs ± 26.478 μs  ┊ GC (mean ± σ):  1.49% ±  0.99%

  ▂██▅▄▂        ▄▇▇▅▃▁     ▂▃▅▅▄▂▁    ▁▂▂▁                    ▂
  ███████▆▆▅▃▅▅▂██████▇▆▆▇█████████▅▄▇█████▇▆▆▆▂▆▆▆▇▅▅▂▄▅▄▅▃▅ █
  16.1 μs      Histogram: log(frequency) by time      22.1 μs <

 Memory estimate: 5.62 KiB, allocs estimate: 7.
```

The following benchmark demonstrates that this change leads to a noticeable speedup in practice (`~5.8%` here).

Main:

```julia
julia> pgn = "1. e4 c6 2. Nf3 d5 3. exd5 cxd5 4. d4 Nc6 5. Nc3 e6 6. Be2 Bd6 7. O-O Nf6 8. Bg5 O-O 9. Qd2 Be7 10. Rfe1 Qc7 11. Bf4 Qd7 12. Bb5 a6 13. Ba4 b5 14. Bb3 Qa7 15. Nh4 Qd7 16. Bh6 gxh6 17. Qxh6 Ne4 18. Nxe4 dxe4 19. Rxe4 f5 20. Rxe6 Kh8 21. Nxf5 Rxf5 22. Rae1 Bf8 23. Qh3 Rg5 24. Re1e4 Qg7 25. g3 Bxe6 26. Bxe6 Re8 27. d5 Ne5 28. f4 Nf3+ 29. Kh1 Rg6 30. f5 Rg5 31. Kg2 Nd4 32. c3 Nxe6 33. dxe6 Bd6 34. g4 Qf6 35. Qd3 Bb8 36. Qd7 Qh6 37. e7 Qxh2+ 38. Kf3 Qg3+ 39. Ke2 Qg2+ 40. Kd1 Qxe4 41. Qxe8+ Rg8 42. Qf7 Qxg4+ 43. Kc2 Qg2+ 44. Kb3 a5 45. e8=Q a4+ 46. Ka3 Bd6+ 47. b4 axb3+ 48. Kxb3 Rxe8 49. Qxe8+ Kg7 50. Qd7+ Kh6 51. Qxd6+ Kg5 52. f6 Qf3 53. Qe5+ Kg6 54. Qxb5 Qxf6 55. a4 Qe6+ 56. Ka3 Qd6+ 57. Qb4 Qd3 58. a5 h5 59. Qb6+ Kg5 60. Qc5+ Kg4 61. Kb4 Qb1+ 62. Kc4 Qa2+ 63. Kd3 Qb1+ 64. Kc4 Qa2+ 65. Kd4 Qd2+ 66. Kc4 Qa2+ 67. Kb5 Qb3+ 68. Qb4+ Qxb4+ 69. Kxb4 h4 70. a6 h3 71. a7 h2 72. a8=Q h1=B 73. Qxh1 Kf4 74. c4 Kg3 75. Qe1+ Kf3 76. Qd2 Ke4 77. Qc3 Kf4 78. Qd3 Ke5 79. c5 Ke6 80. c6 Ke5 81. c7 Ke6 82. Qd4 Ke7 83. c8=Q Kf7 84. Qd6 Kg7 85. Qcc7+ Kg8 86. Qdd8# 1-0";

julia> s = Chess.PGN.gamefromstring(pgn);

julia> @benchmark Chess.PGN.gamefromstring(pgn)
BenchmarkTools.Trial: 8676 samples with 1 evaluation.
 Range (min … max):  524.866 μs …   3.473 ms  ┊ GC (min … max): 0.00% … 81.98%
 Time  (median):     546.503 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   572.624 μs ± 246.902 μs  ┊ GC (mean ± σ):  4.23% ±  8.02%

  ▇██▅▃▁                                                        ▂
  ██████▆▅▄▃▄▇▇█▆▄▅▄▄▃▅▄▃▄▁▄▁▃▄▁▁▁▁▁▁▄▁▁▁▁▁▁▁▁▁▁▁▁▁▁▃▁▁▃▁▁▁▁▁▁▃ █
  525 μs        Histogram: log(frequency) by time       1.18 ms <

 Memory estimate: 441.47 KiB, allocs estimate: 3036.
```

This PR:

```julia
julia> pgn = "1. e4 c6 2. Nf3 d5 3. exd5 cxd5 4. d4 Nc6 5. Nc3 e6 6. Be2 Bd6 7. O-O Nf6 8. Bg5 O-O 9. Qd2 Be7 10. Rfe1 Qc7 11. Bf4 Qd7 12. Bb5 a6 13. Ba4 b5 14. Bb3 Qa7 15. Nh4 Qd7 16. Bh6 gxh6 17. Qxh6 Ne4 18. Nxe4 dxe4 19. Rxe4 f5 20. Rxe6 Kh8 21. Nxf5 Rxf5 22. Rae1 Bf8 23. Qh3 Rg5 24. Re1e4 Qg7 25. g3 Bxe6 26. Bxe6 Re8 27. d5 Ne5 28. f4 Nf3+ 29. Kh1 Rg6 30. f5 Rg5 31. Kg2 Nd4 32. c3 Nxe6 33. dxe6 Bd6 34. g4 Qf6 35. Qd3 Bb8 36. Qd7 Qh6 37. e7 Qxh2+ 38. Kf3 Qg3+ 39. Ke2 Qg2+ 40. Kd1 Qxe4 41. Qxe8+ Rg8 42. Qf7 Qxg4+ 43. Kc2 Qg2+ 44. Kb3 a5 45. e8=Q a4+ 46. Ka3 Bd6+ 47. b4 axb3+ 48. Kxb3 Rxe8 49. Qxe8+ Kg7 50. Qd7+ Kh6 51. Qxd6+ Kg5 52. f6 Qf3 53. Qe5+ Kg6 54. Qxb5 Qxf6 55. a4 Qe6+ 56. Ka3 Qd6+ 57. Qb4 Qd3 58. a5 h5 59. Qb6+ Kg5 60. Qc5+ Kg4 61. Kb4 Qb1+ 62. Kc4 Qa2+ 63. Kd3 Qb1+ 64. Kc4 Qa2+ 65. Kd4 Qd2+ 66. Kc4 Qa2+ 67. Kb5 Qb3+ 68. Qb4+ Qxb4+ 69. Kxb4 h4 70. a6 h3 71. a7 h2 72. a8=Q h1=B 73. Qxh1 Kf4 74. c4 Kg3 75. Qe1+ Kf3 76. Qd2 Ke4 77. Qc3 Kf4 78. Qd3 Ke5 79. c5 Ke6 80. c6 Ke5 81. c7 Ke6 82. Qd4 Ke7 83. c8=Q Kf7 84. Qd6 Kg7 85. Qcc7+ Kg8 86. Qdd8# 1-0";

julia> s = Chess.PGN.gamefromstring(pgn);

julia> @benchmark Chess.PGN.gamefromstring(pgn)
BenchmarkTools.Trial: 9120 samples with 1 evaluation.
 Range (min … max):  505.489 μs …   5.532 ms  ┊ GC (min … max): 0.00% … 86.61%
 Time  (median):     514.903 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   544.595 μs ± 246.866 μs  ┊ GC (mean ± σ):  4.43% ±  8.08%

  █▁▁                                                            
  ███▃▂▂▂▂▂▁▁▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▁▂▁▂▁▂▁▂▁▂▁▁▂▁▂▁▂▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁▁▂ ▂
  505 μs           Histogram: frequency by time         1.04 ms <

 Memory estimate: 441.47 KiB, allocs estimate: 3036.
```