### PR TITLE
Relax `::String` parameters to `::AbstractString`

### DIFF
--- a/src/board.jl
+++ b/src/board.jl
@@ -270,7 +270,7 @@ end
 """
     pieceon(b::Board, s::Square)
     pieceon(b::Board, f::SquareFile, r::SquareRank)
-    pieceon(b::Board, s::String)
+    pieceon(b::Board, s::AbstractString)
 
 Find the piece on the given square of the board.
 
@@ -300,7 +300,7 @@ function pieceon(b::Board, f::SquareFile, r::SquareRank)::Piece
     pieceon(b, Square(f, r))
 end
 
-function pieceon(b::Board, s::String)
+function pieceon(b::Board, s::AbstractString)
     pieceon(b, squarefromstring(s))
 end
 
@@ -1113,8 +1113,8 @@ end
 
 """
     see(b::Board, m::Move)::Int
-    see(b::Board, m::String)::Int
-    see(b::Board, m::String, movelist::MoveList)::Int
+    see(b::Board, m::AbstractString)::Int
+    see(b::Board, m::AbstractString, movelist::MoveList)::Int
 
 Static exchange evaluator.
 
@@ -1123,7 +1123,7 @@ search, just looking at the attackers and defenders of the destination square,
 including X-ray attackers and defenders. It does not consider pins, overloaded
 pieces, etc., and is therefore only reliable as a very rough guess.
 
-In the `m::String`, `see` internally calls `movesfromsan`, which can be
+In the `m::AbstractString`, `see` internally calls `movesfromsan`, which can be
 supplied  a pre-allocated `MoveList`in order to save time/space due to
 unnecessary allocations. If provided, the `movelist` parameter will be
 passed to `moves`. It is up to the caller to ensure that `movelist` has
@@ -1238,8 +1238,8 @@ function see(b::Board, m::Move)::Int
     swaplist[1]
 end
 
-see(b::Board, m::String)::Int = see(b, m, MoveList(200))
-function see(b::Board, m::String, movelist::MoveList)::Int
+see(b::Board, m::AbstractString)::Int = see(b, m, MoveList(200))
+function see(b::Board, m::AbstractString, movelist::MoveList)::Int
     mv = movefromstring(m)
     if isnothing(mv)
         mv = movefromsan(b, m, movelist)
@@ -1564,7 +1564,7 @@ discovered_check_candidates(b::Board) = discovered_check_candidates(b, sidetomov
 
 """
     domove(b::Board, m::Move)
-    domove(b::Board, m::String)
+    domove(b::Board, m::AbstractString)
 
 Do the move `m` on the board `b`, and return the new board.
 
@@ -1652,7 +1652,7 @@ function domove(b::Board, m::Move)::Board
     result
 end
 
-function domove(b::Board, m::String)::Board
+function domove(b::Board, m::AbstractString)::Board
     mv = movefromstring(m)
     if isnothing(mv)
         mv = movefromsan(b, m)
@@ -1682,7 +1682,7 @@ Base.show(io::IO, _::UndoInfo) = print(io, "UndoInfo(...)")
 
 """
     domove!(b::Board, m::Move)
-    domove!(b::Board, m::String)
+    domove!(b::Board, m::AbstractString)
 
 Destructively modify the board `b` by making the move `m`.
 
@@ -1785,7 +1785,7 @@ function domove!(b::Board, m::Move)::UndoInfo
     result
 end
 
-function domove!(b::Board, m::String)::UndoInfo
+function domove!(b::Board, m::AbstractString)::UndoInfo
     mv = movefromstring(m)
     if isnothing(mv)
         mv = movefromsan(b, m)
@@ -3422,14 +3422,14 @@ end
 
 
 """
-    fromfen(fen::String)
+    fromfen(fen::AbstractString)
 
 Try to create a `Board` value from a FEN string.
 
 If the supplied string doesn't represent a valid board position, this function
 returns `nothing`.
 """
-function fromfen(fen::String)::Union{Board,Nothing}
+function fromfen(fen::AbstractString)::Union{Board,Nothing}
     result = emptyboard()
     components = split(fen, r"\s+")
 

--- a/src/book.jl
+++ b/src/book.jl
@@ -289,7 +289,7 @@ end
 
 function addgamefile!(
     entries::Vector{BookEntry},
-    filename::String,
+    filename::AbstractString,
     scorewhitewin,
     scorewhitedraw,
     scorewhiteloss,
@@ -439,7 +439,7 @@ end
 
 
 """
-    writebooktofile(entries::Vector{BookEntry}, filename::String,
+    writebooktofile(entries::Vector{BookEntry}, filename::AbstractString,
                     compact = false)
 
 Writes a book (as created by `createbookfile`) to a binary file.
@@ -447,7 +447,7 @@ Writes a book (as created by `createbookfile`) to a binary file.
 If the optional parameter `compact` is `true`, the book is written in a more
 compact format that does not include W/L/D counts, Elo numbers and years.
 """
-function writebooktofile(entries::Vector{BookEntry}, filename::String, compact = false)
+function writebooktofile(entries::Vector{BookEntry}, filename::AbstractString, compact = false)
     open(filename, "w") do f
         write(f, UInt8(compact ? 1 : 0))
         for e ∈ entries
@@ -458,7 +458,7 @@ end
 
 
 """
-    purgebook(infilename::String, outfilename::String;
+    purgebook(infilename::AbstractString, outfilename::AbstractString;
               minscore = 0, mingamecount = 5, compact = false)
 
 Creates a smaller version of an opening book file by removing unimportant lines.
@@ -470,8 +470,8 @@ If the optional parameter `compact` is `true`, the output file is written in a
 more compact format that does not include W/L/D counts, Elo numbers and years.
 """
 function purgebook(
-    infilename::String,
-    outfilename::String;
+    infilename::AbstractString,
+    outfilename::AbstractString;
     minscore = 0,
     mingamecount = 5,
     compact = false,

--- a/src/game.jl
+++ b/src/game.jl
@@ -195,12 +195,12 @@ end
 
 
 """
-    SimpleGame(startfen::String)
+    SimpleGame(startfen::AbstractString)
 
 Constructor that creates a `SimpleGame` from the position given by the provided
 FEN string.
 """
-function SimpleGame(startfen::String)
+function SimpleGame(startfen::AbstractString)
     SimpleGame(fromfen(startfen))
 end
 
@@ -387,12 +387,12 @@ end
 
 
 """
-    Game(startfen::String)
+    Game(startfen::AbstractString)
 
 Constructor that creates a `Game` from the position given by the provided FEN
 string.
 """
-function Game(startfen::String)
+function Game(startfen::AbstractString)
     Game(fromfen(startfen))
 end
 
@@ -446,16 +446,16 @@ function SimpleGame(g::Game)
 end
 
 """
-    headervalue(ghs::GameHeaders, name::String)
-    headervalue(g::SimpleGame, name::String)
-    headervalue(g::Game, name::String)
+    headervalue(ghs::GameHeaders, name::AbstractString)
+    headervalue(g::SimpleGame, name::AbstractString)
+    headervalue(g::Game, name::AbstractString)
 
 Looks up the value for the header with the given name.
 
 Returns the value as a `String`, or `nothing` if no header with the provided
 name exists.
 """
-function headervalue(ghs::GameHeaders, name::String)::Union{String,Nothing}
+function headervalue(ghs::GameHeaders, name::AbstractString)::Union{String,Nothing}
     if name == "Event"
         ghs.event
     elseif name == "Site"
@@ -482,11 +482,11 @@ function headervalue(ghs::GameHeaders, name::String)::Union{String,Nothing}
     end
 end
 
-function headervalue(g::SimpleGame, name::String)::Union{String,Nothing}
+function headervalue(g::SimpleGame, name::AbstractString)::Union{String,Nothing}
     headervalue(g.headers, name)
 end
 
-function headervalue(g::Game, name::String)::Union{String,Nothing}
+function headervalue(g::Game, name::AbstractString)::Union{String,Nothing}
     headervalue(g.headers, name)
 end
 
@@ -496,7 +496,7 @@ const PGN_DATE_FORMAT_2 = DateFormat("y-m")
 const PGN_DATE_FORMAT_3 = DateFormat("y")
 
 
-function parsedate(datestr::String)::Union{Date,Nothing}
+function parsedate(datestr::AbstractString)::Union{Date,Nothing}
     datestr = replace(datestr, "." => "-")
     try
         Date(datestr[1:10], PGN_DATE_FORMAT)
@@ -680,13 +680,13 @@ end
 
 
 """
-    setheadervalue!(ghs::GameHeaders, name::String, value::String)
-    setheadervalue!(g::SimpleGame, name::String, value::String)
-    setheadervalue!(g::Game, name::String, value::String)
+    setheadervalue!(ghs::GameHeaders, name::AbstractString, value::AbstractString)
+    setheadervalue!(g::SimpleGame, name::AbstractString, value::AbstractString)
+    setheadervalue!(g::Game, name::AbstractString, value::AbstractString)
 
 Sets a header value, creating the header if it doesn't exist.
 """
-function setheadervalue!(ghs::GameHeaders, name::String, value::String)
+function setheadervalue!(ghs::GameHeaders, name::AbstractString, value::AbstractString)
     if name == "Event"
         ghs.event = value
     elseif name == "Site"
@@ -714,11 +714,11 @@ function setheadervalue!(ghs::GameHeaders, name::String, value::String)
     end
 end
 
-function setheadervalue!(g::SimpleGame, name::String, value::String)
+function setheadervalue!(g::SimpleGame, name::AbstractString, value::AbstractString)
     setheadervalue!(g.headers, name, value)
 end
 
-function setheadervalue!(g::Game, name::String, value::String)
+function setheadervalue!(g::Game, name::AbstractString, value::AbstractString)
     setheadervalue!(g.headers, name, value)
 end
 
@@ -814,9 +814,9 @@ end
 
 """
     domove!(g::SimpleGame, m::Move)
-    domove!(g::SimpleGame, m::String)
+    domove!(g::SimpleGame, m::AbstractString)
     domove!(g::Game, m::Move)
-    domove!(g::Game, m::String)
+    domove!(g::Game, m::AbstractString)
 
 Adds a new move at the current location in the game move list.
 
@@ -843,7 +843,7 @@ function domove!(g::SimpleGame, m::Move)
     g
 end
 
-function domove!(g::SimpleGame, m::String)
+function domove!(g::SimpleGame, m::AbstractString)
     mv = movefromstring(m)
     if isnothing(mv)
         mv = movefromsan(board(g), m)
@@ -857,7 +857,7 @@ function domove!(g::Game, m::Move)
     g
 end
 
-function domove!(g::Game, m::String)
+function domove!(g::Game, m::AbstractString)
     removeallchildren!(g)
     addmove!(g, m)
 end
@@ -895,7 +895,7 @@ end
 
 """
     addmove!(g::Game, m::Move)
-    addmove!(g::Game, m::String)
+    addmove!(g::Game, m::AbstractString)
 
 Adds the move `m` to the game `g` at the current node.
 
@@ -919,7 +919,7 @@ function addmove!(g::Game, m::Move)
     g
 end
 
-function addmove!(g::Game, m::String)
+function addmove!(g::Game, m::AbstractString)
     mv = movefromstring(m)
     if isnothing(mv)
         mv = movefromsan(board(g), m)
@@ -1064,7 +1064,7 @@ end
     forward!(g::SimpleGame)
     forward!(g::Game)
     forward!(g::Game, m::Move)
-    forward!(g::Game, m::String)
+    forward!(g::Game, m::AbstractString)
 
 Go one step forward in the game by replaying a previously retracted move.
 
@@ -1097,7 +1097,7 @@ function forward!(g::Game, m::Move)
     g
 end
 
-function forward!(g::Game, m::String)
+function forward!(g::Game, m::AbstractString)
     mv = movefromstring(m)
     if isnothing(mv)
         mv = movefromsan(board(g), m)
@@ -1281,77 +1281,77 @@ end
 
 
 """
-    adddata!(n::GameNode, key::String, value)
+    adddata!(n::GameNode, key::AbstractString, value)
 
 Add a piece of data to the given node's data dictionary.
 
 This is a low-level function that is mainly used to add comments and NAGs, but
 can also be used to add any type of custom annotation data to a game node.
 """
-function adddata!(n::GameNode, key::String, value)
+function adddata!(n::GameNode, key::AbstractString, value)
     n.data[key] = value
 end
 
 
 """
-    adddata!(g::Game, key::String, value)
+    adddata!(g::Game, key::AbstractString, value)
 
 Add a piece of data to the current game node's data dictionary.
 
 This is a low-level function that is mainly used to add comments and NAGs, but
 can also be used to add any type of custom annotation data to a game node.
 """
-function adddata!(g::Game, key::String, value)
+function adddata!(g::Game, key::AbstractString, value)
     adddata!(g.node, key, value)
 end
 
 
 """
-    removedata!(n::GameNode, key::String)
+    removedata!(n::GameNode, key::AbstractString)
 
 Remove a piece of data from the game node's data dictionary.
 
 This is a low-level function that is mainly used to delete comments and NAGs.
 """
-function removedata!(n::GameNode, key::String)
+function removedata!(n::GameNode, key::AbstractString)
     delete!(n.data, key)
 end
 
 
 """
-    removedata!(n::GameNode, key::String)
+    removedata!(n::GameNode, key::AbstractString)
 
 Remove a piece of data from the current game node's data dictionary.
 
 This is a low-level function that is mainly used to delete comments and NAGs.
 """
-function removedata!(g::Game, key::String)
+function removedata!(g::Game, key::AbstractString)
     removedata!(g.node, key)
 end
 
 
 """
-    addcomment!(g::Game, comment::String)
+    addcomment!(g::Game, comment::AbstractString)
 
 Adds a comment to the current game node.
 
 In PGN and other text ouput formats, the comment is printed _after_ the move
 leading to the node.
 """
-function addcomment!(g::Game, comment::String)
+function addcomment!(g::Game, comment::AbstractString)
     adddata!(g, "comment", comment)
 end
 
 
 """
-    addprecomment!(g::Game, comment::String)
+    addprecomment!(g::Game, comment::AbstractString)
 
 Adds a pre-comment to the current game node.
 
 In PGN and other text ouput formats, the comment is printed _before_ the move
 leading to the node.
 """
-function addprecomment!(g::Game, comment::String)
+function addprecomment!(g::Game, comment::AbstractString)
     adddata!(g, "precomment", comment)
 end
 

--- a/src/move.jl
+++ b/src/move.jl
@@ -156,7 +156,7 @@ end
 
 
 """
-    movefromstring(s::String)
+    movefromstring(s::AbstractString)
 
 Convert a UCI move string to a move.
 
@@ -178,7 +178,7 @@ julia> movefromstring("") == nothing
 true
 ```
 """
-function movefromstring(s::String)::Union{Move,Nothing}
+function movefromstring(s::AbstractString)::Union{Move,Nothing}
     if s == "0000"
         return MOVE_NULL
     elseif length(s) < 4

--- a/src/pgn.jl
+++ b/src/pgn.jl
@@ -530,7 +530,7 @@ end
 
 
 """
-    gamesinfile(filename::String; annotations=false, skip=0, movelist::MoveList=MoveList(200))
+    gamesinfile(filename::AbstractString; annotations=false, skip=0, movelist::MoveList=MoveList(200))
 
 Creates a `Channel` of `Game`/`SimpleGame` objects read from the PGN file with
 the provided file name.
@@ -548,7 +548,7 @@ It is up to the caller to ensure that `movelist` has sufficient capacity.
 The optional parameter `skip` makes the function skip the first `skip` games of
 the file.
 """
-gamesinfile(filename::String; annotations = false, skip = 0, movelist::MoveList = MoveList(200)) = gamesfromstream(open(filename, "r"), annotations = annotations, skip = skip, movelist = MoveList(200))
+gamesinfile(filename::AbstractString; annotations = false, skip = 0, movelist::MoveList = MoveList(200)) = gamesfromstream(open(filename, "r"), annotations = annotations, skip = skip, movelist = MoveList(200))
 
 """
     gamesfromstream(stream::IO; annotations=false, skip=0, movelist::MoveList=MoveList(200))
@@ -592,7 +592,7 @@ end
 
 
 """
-    gamefromstring(s::String; annotations=false, movelist::MoveList=MoveList(200))
+    gamefromstring(s::AbstractString; annotations=false, movelist::MoveList=MoveList(200))
 
 Attempts to create a `Game` or `SimpleGame` object from the provided PGN string.
 
@@ -609,17 +609,17 @@ sufficient capacity.
 If the string does not parse as valid PGN, or if the notation contains illegal
 or ambiguous moves, the function raises a `PGNException`.
 """
-function gamefromstring(s::String; annotations = false, movelist::MoveList=MoveList(200))
+function gamefromstring(s::AbstractString; annotations = false, movelist::MoveList=MoveList(200))
     readgame(PGNReader(IOBuffer(s)), annotations = annotations, movelist = movelist)
 end
 
 
-function formatstring(s::String)::String
+function formatstring(s::AbstractString)::String
     "\"" * replace(replace(s, "\\" => "\\\\"), "\"" => "\\\"") * "\""
 end
 
 
-function formatheader(name::String, value::String)
+function formatheader(name::AbstractString, value::AbstractString)
     "[" * name * " " * formatstring(value) * "]\n"
 end
 

--- a/src/san.jl
+++ b/src/san.jl
@@ -14,8 +14,8 @@ end
 
 
 """
-    movefromsan(b::Board, san::String, movelist::MoveList)::Union{Move,Nothing}
-    movefromsan(b::Board, san::String)::Union{Move,Nothing}
+    movefromsan(b::Board, san::AbstractString, movelist::MoveList)::Union{Move,Nothing}
+    movefromsan(b::Board, san::AbstractString)::Union{Move,Nothing}
 
 Tries to read a move in Short Algebraic Notation.
 
@@ -42,9 +42,9 @@ julia> movefromsan(b, "???") == nothing
 true
 ```
 """
-movefromsan(b::Board, san::String)::Union{Move,Nothing} = movefromsan(b, san, MoveList(200))
+movefromsan(b::Board, san::AbstractString)::Union{Move,Nothing} = movefromsan(b, san, MoveList(200))
 
-function movefromsan(b::Board, san::String, movelist::MoveList)::Union{Move,Nothing}
+function movefromsan(b::Board, san::AbstractString, movelist::MoveList)::Union{Move,Nothing}
     recycle!(movelist)
     ms = moves(b, movelist)
 

--- a/src/uci.jl
+++ b/src/uci.jl
@@ -76,7 +76,7 @@ mutable struct Option
 end
 
 
-function parseoptionname(s::String)::Tuple{String,String}
+function parseoptionname(s::AbstractString)::Tuple{String,String}
     @assert startswith(s, "name ")
     result = ""
     for c in s[6:end]
@@ -87,7 +87,7 @@ function parseoptionname(s::String)::Tuple{String,String}
 end
 
 
-function parseoptiontype(s::String)::Tuple{OptionType,String}
+function parseoptiontype(s::AbstractString)::Tuple{OptionType,String}
     @assert startswith(s, "type ")
     result = ""
     for c in s[6:end]
@@ -105,7 +105,7 @@ function parseoptiontype(s::String)::Tuple{OptionType,String}
 end
 
 
-function parseoptiondefault(ot::OptionType, s::String)::Tuple{OptionValue,String}
+function parseoptiondefault(ot::OptionType, s::AbstractString)::Tuple{OptionValue,String}
     if ot == button
         (nothing, s)
     else
@@ -134,7 +134,7 @@ function parseoptiondefault(ot::OptionType, s::String)::Tuple{OptionValue,String
 end
 
 
-function parsespinminmax(s::String)::Tuple{Int,Int}
+function parsespinminmax(s::AbstractString)::Tuple{Int,Int}
     @assert startswith(s, " min ")
     tokens = split(s[2:end], r"\s+")
     @assert length(tokens) >= 4
@@ -143,7 +143,7 @@ function parsespinminmax(s::String)::Tuple{Int,Int}
 end
 
 
-function parsecombovar(s::String)::Tuple{String,String}
+function parsecombovar(s::AbstractString)::Tuple{String,String}
     @assert startswith(s, "var ")
     result = ""
     for c in s[5:end]
@@ -158,7 +158,7 @@ function parsecombovar(s::String)::Tuple{String,String}
 end
 
 
-function parsecombovars(s::String)::Vector{String}
+function parsecombovars(s::AbstractString)::Vector{String}
     result = String[]
     while startswith(s, "var ")
         (next, rest) = parsecombovar(s)
@@ -169,7 +169,7 @@ function parsecombovars(s::String)::Vector{String}
 end
 
 
-function parseoption(s::String)::Option
+function parseoption(s::AbstractString)::Option
     @assert startswith(s, "option name")
     s = s[8:end]
     (name, s) = parseoptionname(s)
@@ -245,11 +245,11 @@ Base.show(io::IO, engine::Engine) = print(io, "Engine: $(engine.name)")
 
 
 """
-    function runengine(path::String)::Engine
+    function runengine(path::AbstractString)::Engine
 
 Runs the engine at the specified path, returning an `Engine`.
 """
-function runengine(path::String)::Engine
+function runengine(path::AbstractString)::Engine
     process = open(`$path`, "r+")
     options = Dict{String,Option}()
     println(process, "uci")
@@ -289,11 +289,11 @@ end
 
 
 """
-    sendcommand(e::Engine, cmd::String)
+    sendcommand(e::Engine, cmd::AbstractString)
 
 Sends the UCI command `cmd` to the engine `e`.
 """
-function sendcommand(e::Engine, cmd::String)
+function sendcommand(e::Engine, cmd::AbstractString)
     println(e.io, cmd)
 end
 
@@ -324,14 +324,14 @@ end
 
 
 """
-    function setoption(e::Engine, name::String, value::OptionValue = nothing)
+    function setoption(e::Engine, name::AbstractString, value::OptionValue = nothing)
 
 Sets the UCI option named `name` to the new value `value`.
 
 Throws an error if the engine `e` does not have an option with the provided
 name, or if the value is incompatible with the type of the option.
 """
-function setoption(e::Engine, name::String, value::OptionValue = nothing)
+function setoption(e::Engine, name::AbstractString, value::OptionValue = nothing)
     if !haskey(e.options, name)
         throw("Engine $(e.name) has no option named $name")
     elseif !isvalidvalueforoption(e.options[name], value)
@@ -506,11 +506,11 @@ end
 
 
 """
-    parsebestmove(line::String)::BestMoveInfo
+    parsebestmove(line::AbstractString)::BestMoveInfo
 
 Parses a `bestmove` line printed by a UCI engine to a `BestMoveInfo` object.
 """
-function parsebestmove(line::String)::BestMoveInfo
+function parsebestmove(line::AbstractString)::BestMoveInfo
     @assert startswith(line, "bestmove")
     tokens = split(line, r"\s+")
     bestmove = movefromstring(String(tokens[2]))
@@ -676,14 +676,14 @@ end
 
 
 """
-    parsesearchinfo(line::String)::SearchInfo
+    parsesearchinfo(line::AbstractString)::SearchInfo
 
 Parses an `info` line printed by a UCI engine to a `SearchInfo` object.
 
 See the documentation for `SearchInfo` for information about how to inspect
 and use the return value.
 """
-function parsesearchinfo(line::String)::SearchInfo
+function parsesearchinfo(line::AbstractString)::SearchInfo
     @assert startswith(line, "info")
     result = SearchInfo()
     tokens = split(line, r"\s+")[2:end]
@@ -724,7 +724,7 @@ end
 
 
 """
-    function search(e::Engine, gocmd::String; infoaction = nothing)
+    function search(e::Engine, gocmd::AbstractString; infoaction = nothing)
 
 Tells a UCI engine to start searching.
 
@@ -736,7 +736,7 @@ of `parsesearchinfo()`.
 
 The return value is of type `BestMoveInfo`.
 """
-function search(e::Engine, gocmd::String; infoaction = nothing)::BestMoveInfo
+function search(e::Engine, gocmd::AbstractString; infoaction = nothing)::BestMoveInfo
     sendcommand(e, gocmd)
     while true
         line = readline(e.io)
@@ -858,7 +858,7 @@ function mpvsearch(
 
     result = SearchInfo[]
 
-    function infoaction(info::String)
+    function infoaction(info::AbstractString)
         info = parsesearchinfo(info)
         if !isnothing(info.multipv)
             info.multipv == 1 && empty!(result)

--- a/test/board.jl
+++ b/test/board.jl
@@ -237,20 +237,22 @@ begin
 end
 
 begin
-    fens = [
-        "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq -",
-        "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w Kq -",
-        "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w Qk -",
-        "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - -",
-        "rnbqkbnr/pppp1ppp/4p3/4P3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6",
-    ]
-    for f in fens
-        @test fen(fromfen(f)) == f
-    end
+    for T in [String, SubString]
+        fens = T.([
+            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq -",
+            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w Kq -",
+            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w Qk -",
+            "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - -",
+            "rnbqkbnr/pppp1ppp/4p3/4P3/8/8/PPPP1PPP/RNBQKBNR w KQkq d6",
+        ])
+        for f in fens
+            @test fen(fromfen(f)) == f
+        end
 
-    for i = 0:959
-        f = chess960fen(i)
-        @test fen(fromfen(f)) == f
+        for i = 0:959
+            f = chess960fen(i)
+            @test fen(fromfen(f)) == f
+        end
     end
 end
 

--- a/test/game.jl
+++ b/test/game.jl
@@ -1,30 +1,34 @@
 begin
-    pgn = "1. d4 e5 2. c4 f5 3. Nc3 (3. Nf3 Nf6 4. g3) 3... Na6 4. e4"
-    g = Chess.PGN.gamefromstring(pgn; annotations=true)
-    s = Chess.PGN.gamefromstring(pgn)
-    s_g = SimpleGame(g)
+    for T in [String, SubString]
+        pgn = T("1. d4 e5 2. c4 f5 3. Nc3 (3. Nf3 Nf6 4. g3) 3... Na6 4. e4")
+        g = Chess.PGN.gamefromstring(pgn; annotations=true)
+        s = Chess.PGN.gamefromstring(pgn)
+        s_g = SimpleGame(g)
 
-    toend!(g)
-    toend!(s)
-    toend!(s_g)
+        toend!(g)
+        toend!(s)
+        toend!(s_g)
 
-    @assert fen(board(g)) == fen(board(s))
-    @assert fen(board(s)) == fen(board(s_g)) 
+        @assert fen(board(g)) == fen(board(s))
+        @assert fen(board(s)) == fen(board(s_g))
+    end
 end
 
 begin
-    pgn = "1. e4 c6 2. Nf3 d5 3. exd5 cxd5 4. d4 Nc6 5. Nc3 e6 6. Be2 Bd6 7. O-O Nf6"
-    g = Chess.PGN.gamefromstring(pgn; annotations=true)
-    s = Chess.PGN.gamefromstring(pgn)
-    s_g = SimpleGame(g)
-    g_s = Game(s)
+    for T in [String, SubString]
+        pgn = T("1. e4 c6 2. Nf3 d5 3. exd5 cxd5 4. d4 Nc6 5. Nc3 e6 6. Be2 Bd6 7. O-O Nf6")
+        g = Chess.PGN.gamefromstring(pgn; annotations=true)
+        s = Chess.PGN.gamefromstring(pgn)
+        s_g = SimpleGame(g)
+        g_s = Game(s)
 
-    toend!(g)
-    toend!(s)
-    toend!(s_g)
-    toend!(g_s)
+        toend!(g)
+        toend!(s)
+        toend!(s_g)
+        toend!(g_s)
 
-    @assert fen(board(g)) == fen(board(s))
-    @assert fen(board(s)) == fen(board(s_g)) 
-    @assert fen(board(s_g)) == fen(board(g_s))
+        @assert fen(board(g)) == fen(board(s))
+        @assert fen(board(s)) == fen(board(s_g)) 
+        @assert fen(board(s_g)) == fen(board(g_s))
+    end
 end

--- a/test/san.jl
+++ b/test/san.jl
@@ -1,63 +1,65 @@
 begin
-    local movelist = MoveList(200)
-    local b = fromfen("2r2k2/1P6/8/8/p7/2N3N1/8/R3K2R w KQ -")
-    @test movefromsan(b, "b8=Q", movelist) == Move(SQ_B7, SQ_B8, QUEEN)
-    @test movefromsan(b, "b8=Q") == Move(SQ_B7, SQ_B8, QUEEN)
-    @test movetosan(b, Move(SQ_B7, SQ_B8, QUEEN)) == "b8=Q"
-    @test movefromsan(b, "bxc8=R+", movelist) == Move(SQ_B7, SQ_C8, ROOK)
-    @test movefromsan(b, "bxc8=R+") == Move(SQ_B7, SQ_C8, ROOK)
-    @test movetosan(b, Move(SQ_B7, SQ_C8, ROOK)) == "bxc8=R+"
-    @test movefromsan(b, "Nxa4", movelist) == Move(SQ_C3, SQ_A4)
-    @test movefromsan(b, "Nxa4") == Move(SQ_C3, SQ_A4)
-    @test movetosan(b, Move(SQ_C3, SQ_A4)) == "Nxa4"
-    @test movefromsan(b, "Nge4", movelist) == Move(SQ_G3, SQ_E4)
-    @test movefromsan(b, "Nge4") == Move(SQ_G3, SQ_E4)
-    @test movetosan(b, Move(SQ_G3, SQ_E4)) == "Nge4"
-    @test movefromsan(b, "Nce4", movelist) == Move(SQ_C3, SQ_E4)
-    @test movefromsan(b, "Nce4") == Move(SQ_C3, SQ_E4)
-    @test movetosan(b, Move(SQ_C3, SQ_E4)) == "Nce4"
-    @test isnothing(movefromsan(b, "Ne4"))
-    @test movefromsan(b, "O-O-O", movelist) == Move(SQ_E1, SQ_C1)
-    @test movefromsan(b, "O-O-O") == Move(SQ_E1, SQ_C1)
-    @test movetosan(b, Move(SQ_E1, SQ_C1)) == "O-O-O"
-    @test movefromsan(b, "O-O+", movelist) == Move(SQ_E1, SQ_G1)
-    @test movefromsan(b, "O-O+") == Move(SQ_E1, SQ_G1)
-    @test movetosan(b, Move(SQ_E1, SQ_G1)) == "O-O+"
+    for T in [String, SubString]
+        local movelist = MoveList(200)
+        local b = fromfen(T("2r2k2/1P6/8/8/p7/2N3N1/8/R3K2R w KQ -"))
+        @test movefromsan(b, T("b8=Q"), movelist) == Move(SQ_B7, SQ_B8, QUEEN)
+        @test movefromsan(b, T("b8=Q")) == Move(SQ_B7, SQ_B8, QUEEN)
+        @test movetosan(b, Move(SQ_B7, SQ_B8, QUEEN)) == "b8=Q"
+        @test movefromsan(b, T("bxc8=R+"), movelist) == Move(SQ_B7, SQ_C8, ROOK)
+        @test movefromsan(b, T("bxc8=R+")) == Move(SQ_B7, SQ_C8, ROOK)
+        @test movetosan(b, Move(SQ_B7, SQ_C8, ROOK)) == "bxc8=R+"
+        @test movefromsan(b, T("Nxa4"), movelist) == Move(SQ_C3, SQ_A4)
+        @test movefromsan(b, T("Nxa4")) == Move(SQ_C3, SQ_A4)
+        @test movetosan(b, Move(SQ_C3, SQ_A4)) == "Nxa4"
+        @test movefromsan(b, T("Nge4"), movelist) == Move(SQ_G3, SQ_E4)
+        @test movefromsan(b, T("Nge4")) == Move(SQ_G3, SQ_E4)
+        @test movetosan(b, Move(SQ_G3, SQ_E4)) == "Nge4"
+        @test movefromsan(b, T("Nce4"), movelist) == Move(SQ_C3, SQ_E4)
+        @test movefromsan(b, T("Nce4")) == Move(SQ_C3, SQ_E4)
+        @test movetosan(b, Move(SQ_C3, SQ_E4)) == "Nce4"
+        @test isnothing(movefromsan(b, T("Ne4")))
+        @test movefromsan(b, T("O-O-O"), movelist) == Move(SQ_E1, SQ_C1)
+        @test movefromsan(b, T("O-O-O")) == Move(SQ_E1, SQ_C1)
+        @test movetosan(b, Move(SQ_E1, SQ_C1)) == "O-O-O"
+        @test movefromsan(b, T("O-O+"), movelist) == Move(SQ_E1, SQ_G1)
+        @test movefromsan(b, T("O-O+")) == Move(SQ_E1, SQ_G1)
+        @test movetosan(b, Move(SQ_E1, SQ_G1)) == "O-O+"
 
-    b = fromfen("2r2k2/1P6/8/8/pb6/2N3N1/8/R3K2R w KQ -")
-    @test movefromsan(b, "Ne4", movelist) == Move(SQ_G3, SQ_E4)
-    @test movefromsan(b, "Ne4") == Move(SQ_G3, SQ_E4)
-    @test movetosan(b, Move(SQ_G3, SQ_E4)) == "Ne4"
+        b = fromfen(T("2r2k2/1P6/8/8/pb6/2N3N1/8/R3K2R w KQ -"))
+        @test movefromsan(b, T("Ne4"), movelist) == Move(SQ_G3, SQ_E4)
+        @test movefromsan(b, T("Ne4")) == Move(SQ_G3, SQ_E4)
+        @test movetosan(b, Move(SQ_G3, SQ_E4)) == "Ne4"
 
-    b = fromfen("4k3/R7/8/8/8/8/8/R3K3 w -")
-    @test isnothing(movefromsan(b, "Ra6", movelist))
-    @test isnothing(movefromsan(b, "Ra6"))
-    @test movefromsan(b, "R1a6", movelist) == Move(SQ_A1, SQ_A6)
-    @test movefromsan(b, "R1a6") == Move(SQ_A1, SQ_A6)
-    @test movetosan(b, Move(SQ_A1, SQ_A6)) == "R1a6"
-    @test movefromsan(b, "R7a6", movelist) == Move(SQ_A7, SQ_A6)
-    @test movefromsan(b, "R7a6") == Move(SQ_A7, SQ_A6)
-    @test movetosan(b, Move(SQ_A7, SQ_A6)) == "R7a6"
+        b = fromfen(T("4k3/R7/8/8/8/8/8/R3K3 w -"))
+        @test isnothing(movefromsan(b, T("Ra6"), movelist))
+        @test isnothing(movefromsan(b, T("Ra6")))
+        @test movefromsan(b, T("R1a6"), movelist) == Move(SQ_A1, SQ_A6)
+        @test movefromsan(b, T("R1a6")) == Move(SQ_A1, SQ_A6)
+        @test movetosan(b, Move(SQ_A1, SQ_A6)) == "R1a6"
+        @test movefromsan(b, T("R7a6"), movelist) == Move(SQ_A7, SQ_A6)
+        @test movefromsan(b, T("R7a6")) == Move(SQ_A7, SQ_A6)
+        @test movetosan(b, Move(SQ_A7, SQ_A6)) == "R7a6"
 
-    b = fromfen("4k3/8/8/3q1q2/3q1q2/8/8/4K3 b -")
-    @test isnothing(movefromsan(b, "Qde4#", movelist))
-    @test isnothing(movefromsan(b, "Qfe4#", movelist))
-    @test isnothing(movefromsan(b, "Q4e4#", movelist))
-    @test isnothing(movefromsan(b, "Q5e4#", movelist))
-    @test isnothing(movefromsan(b, "Qde4#"))
-    @test isnothing(movefromsan(b, "Qfe4#"))
-    @test isnothing(movefromsan(b, "Q4e4#"))
-    @test isnothing(movefromsan(b, "Q5e4#"))
-    @test movefromsan(b, "Qd4e4#", movelist) == Move(SQ_D4, SQ_E4)
-    @test movefromsan(b, "Qd4e4#") == Move(SQ_D4, SQ_E4)
-    @test movetosan(b, Move(SQ_D4, SQ_E4)) == "Qd4e4#"
-    @test movefromsan(b, "Qd5e4#", movelist) == Move(SQ_D5, SQ_E4)
-    @test movefromsan(b, "Qd5e4#") == Move(SQ_D5, SQ_E4)
-    @test movetosan(b, Move(SQ_D5, SQ_E4)) == "Qd5e4#"
-    @test movefromsan(b, "Qf4e4#", movelist) == Move(SQ_F4, SQ_E4)
-    @test movefromsan(b, "Qf4e4#") == Move(SQ_F4, SQ_E4)
-    @test movetosan(b, Move(SQ_F4, SQ_E4)) == "Qf4e4#"
-    @test movefromsan(b, "Qf5e4#", movelist) == Move(SQ_F5, SQ_E4)
-    @test movefromsan(b, "Qf5e4#") == Move(SQ_F5, SQ_E4)
-    @test movetosan(b, Move(SQ_F5, SQ_E4)) == "Qf5e4#"
+        b = fromfen(T("4k3/8/8/3q1q2/3q1q2/8/8/4K3 b -"))
+        @test isnothing(movefromsan(b, T("Qde4#"), movelist))
+        @test isnothing(movefromsan(b, T("Qfe4#"), movelist))
+        @test isnothing(movefromsan(b, T("Q4e4#"), movelist))
+        @test isnothing(movefromsan(b, T("Q5e4#"), movelist))
+        @test isnothing(movefromsan(b, T("Qde4#")))
+        @test isnothing(movefromsan(b, T("Qfe4#")))
+        @test isnothing(movefromsan(b, T("Q4e4#")))
+        @test isnothing(movefromsan(b, T("Q5e4#")))
+        @test movefromsan(b, T("Qd4e4#"), movelist) == Move(SQ_D4, SQ_E4)
+        @test movefromsan(b, T("Qd4e4#")) == Move(SQ_D4, SQ_E4)
+        @test movetosan(b, Move(SQ_D4, SQ_E4)) == "Qd4e4#"
+        @test movefromsan(b, T("Qd5e4#"), movelist) == Move(SQ_D5, SQ_E4)
+        @test movefromsan(b, T("Qd5e4#")) == Move(SQ_D5, SQ_E4)
+        @test movetosan(b, Move(SQ_D5, SQ_E4)) == "Qd5e4#"
+        @test movefromsan(b, T("Qf4e4#"), movelist) == Move(SQ_F4, SQ_E4)
+        @test movefromsan(b, T("Qf4e4#")) == Move(SQ_F4, SQ_E4)
+        @test movetosan(b, Move(SQ_F4, SQ_E4)) == "Qf4e4#"
+        @test movefromsan(b, T("Qf5e4#"), movelist) == Move(SQ_F5, SQ_E4)
+        @test movefromsan(b, T("Qf5e4#")) == Move(SQ_F5, SQ_E4)
+        @test movetosan(b, Move(SQ_F5, SQ_E4)) == "Qf5e4#"
+    end
 end


### PR DESCRIPTION
This relaxes every function which takes a `String` parameter to accept `::AbstractString` instead. Importantly, all constructors with string fields are left alone, which is fine because constructors convert types to the expected type during initialization.

This PR is intended to help with things like reading games from files or from data streams where strings are not always materialized (they may be bytes and just acting like string [a la. https://github.com/JuliaStrings/StringViews.jl], views, substrings, etc). In the end, many of these will end up getting converted to strings, but it lifts the burden from the caller to ensure that everything is converted to a string before the callsite.

One concrete usecase is when reading uci strings:

```julia
julia> g = SimpleGame()
SimpleGame:
 *

julia> moves = "d2d4 g8f6"
"d2d4 g8f6"

julia> for m in split(moves, " ")
           domove!(g, m)
       end

julia> g
SimpleGame:
 1. d4 Nf6 *
```

However, `split(moves, " ")` is not a `Vector{String}`:
```julia
julia> split(moves, " ")
2-element Vector{SubString{String}}:
 "d2d4"
 "g8f6"
```

and so `domove!` fails on `master`.